### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/scripts/Base/tooltip.js
+++ b/scripts/Base/tooltip.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
 	$(".tooltip").live({
 		mouseenter : function (e) {
 			var tip = $('#tooltip');
-			tip.html($(this).attr('data-tooltip-content'));
+			tip.text($(this).attr('data-tooltip-content'));
 			tip.show();
 		},
 		mouseleave : function () {
@@ -32,7 +32,7 @@ $(document).ready(function () {
 	});
 	$(".tooltip_sticky").live('mouseenter', function (e) {
 		var tip = $('#tooltip');
-		tip.html($(this).attr('data-tooltip-content'));
+		tip.text($(this).attr('data-tooltip-content'));
 		tip.addClass('tooltip_sticky_div');
 		tip.css({
 			top : e.pageY - tip.outerHeight() / 2,


### PR DESCRIPTION
Fixes [https://github.com/Apocalypsecoder0/Galactic-ConquestV2/security/code-scanning/1](https://github.com/Apocalypsecoder0/Galactic-ConquestV2/security/code-scanning/1)

To fix the problem, we need to ensure that the content from the `data-tooltip-content` attribute is treated as plain text rather than HTML. This can be achieved by using the `text()` method instead of the `html()` method, which will escape any HTML characters and prevent XSS attacks.

We will replace the `html()` method with the `text()` method on lines 6 and 35 in the `scripts/Base/tooltip.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
